### PR TITLE
MDL-52154 lti: Use a different description to the name, for posterity

### DIFF
--- a/ims_cartridge_basic_lti_link.xml
+++ b/ims_cartridge_basic_lti_link.xml
@@ -7,7 +7,7 @@
                           http://www.imsglobal.org/xsd/imslticm_v1p0 imslticm_v1p0.xsd 
                           http://www.imsglobal.org/xsd/imslticp_v1p0 imslticp_v1p0.xsd">
     <title>Example tool</title>
-    <description>Example tool</description>
+    <description>Example tool description</description>
     <extensions platform="my.lms.com">
         <lticm:property name="icon_url">http://download.moodle.org/unittest/test.jpg</lticm:property>
         <lticm:property name="secure_icon_url">https://download.moodle.org/unittest/test.jpg</lticm:property>


### PR DESCRIPTION
Having them different makes unit testing better. Silly me made them the same. Wanted to do this before my unit tests go in core