### PR TITLE
MDLSITE-5297 redir: Correct server var for hostname

### DIFF
--- a/rss_redir.php
+++ b/rss_redir.php
@@ -1,7 +1,7 @@
 <?php
 
 $path = str_replace('rss_redir.php', 'rsstest.xml', $_SERVER['SCRIPT_NAME']);
-$target = 'http://'.$_SERVER['HTTP_HOST'].':'.$_SERVER['SERVER_PORT'].$path;
+$target = 'http://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$path;
 
 header('HTTP/1.1 301 Moved Permanently');
 header("Location: $target");

--- a/test_redir.php
+++ b/test_redir.php
@@ -6,7 +6,7 @@ if (isset($_GET['done']) and $_GET['done'] == 1) {
 }
 
 // Redirect to full self URL.
-$testurl = 'http://'.$_SERVER['HTTP_HOST'].':'.$_SERVER['SERVER_PORT'].$_SERVER['SCRIPT_NAME'];
+$testurl = 'http://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['SCRIPT_NAME'];
 
 $redir = isset($_GET['redir']) ? (int)$_GET['redir'] : 5;
 if ($redir > 10) {


### PR DESCRIPTION
Essentially we currently use HTTP_HOST, and we should use SERVER_NAME.

```
  ["HTTP_HOST"]=>
  string(14) "localhost:8080"
  ["SERVER_NAME"]=>
  string(9) "localhost"
```

Since we already concatenate the port onto the URL in those tests, we currently end up trying to redirect to:
```
localhost:8080:8080
```