### PR TITLE
Add Dockerfile to the repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: bash
+services: docker
+install:
+  - docker build -t moodle-exttests .
+
+script:
+  - "docker run --name test0 -d -p 8000:80 moodle-exttests"
+  - curl --fail -L http://127.0.0.1:8000/test_redir.php
+after_failure:
+  - docker logs test0
+after_script:
+  - docker rm -f test0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:7.1-apache
+
+COPY behat-rsstest.xml /var/www/html
+COPY downloadtests.md5 /var/www/html
+COPY downloadtests.zip /var/www/html
+COPY ical.ics /var/www/html
+COPY ims_cartridge_basic_lti_link.xml /var/www/html
+COPY index.html /var/www/html
+COPY rss_redir.php /var/www/html
+COPY rsstest.xml /var/www/html
+COPY test.html /var/www/html
+COPY test.jpg /var/www/html
+COPY test_agent.php /var/www/html
+COPY test_file.php /var/www/html
+COPY test_file_name.php /var/www/html
+COPY test_post.php /var/www/html
+COPY test_redir.php /var/www/html
+COPY test_redir_proto.php /var/www/html
+COPY test_relative_redir.php /var/www/html


### PR DESCRIPTION
This commit adds a Dockerifle and associated Travis configuration to the repository so that we can have HTTP tests available for testing locally, reducing the burden on external locations.

Note: This does not solve HTTPS tests - that is a significantly harder problem to solve due to the required use of a self-signed cert.