### PR TITLE
By default copy everything, to make auto-builds easier

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+.git
+.gitignore
+.travis.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,3 @@
 FROM php:7.1-apache
 
-COPY behat-rsstest.xml /var/www/html
-COPY downloadtests.md5 /var/www/html
-COPY downloadtests.zip /var/www/html
-COPY ical.ics /var/www/html
-COPY ims_cartridge_basic_lti_link.xml /var/www/html
-COPY index.html /var/www/html
-COPY rss_redir.php /var/www/html
-COPY rsstest.xml /var/www/html
-COPY test.html /var/www/html
-COPY test.jpg /var/www/html
-COPY test_agent.php /var/www/html
-COPY test_file.php /var/www/html
-COPY test_file_name.php /var/www/html
-COPY test_post.php /var/www/html
-COPY test_redir.php /var/www/html
-COPY test_redir_proto.php /var/www/html
-COPY test_relative_redir.php /var/www/html
+COPY . /var/www/html


### PR DESCRIPTION
Till now we needed to, also, edit the Dockerfile with the
exact files to be copied. That was confusing and prone to errors.

Now, all files are copied, but those specified in the .dockerignore