### PR TITLE
MDL-73588 curl: Allow the 302 redirect to actually output something, too

### DIFF
--- a/test_redir.php
+++ b/test_redir.php
@@ -31,3 +31,7 @@ if ($redir <= 1) {
 
 header('HTTP/1.1 302 Found');
 header("Location: $target");
+
+if ($_GET['verbose'] ?? false) {
+    echo "You will be shortly redirected to {$target}";
+}


### PR DESCRIPTION
In order to test MDL-73588 we need to simulate a case when the
redirecting page has some actual output, too. Such an output must not be
present in the final output stream.