### PR TITLE
Add a basic container healthcheck and check for it in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ install:
 
 script:
   - "docker run --name test0 -d -p 8000:80 moodle-exttests"
+  - until [ "`docker inspect -f {{.State.Health.Status}} test0`" == "healthy" ]; do
+        sleep 0.5;
+    done;
   - curl --fail -L http://127.0.0.1:8000/test_redir.php
 after_failure:
   - docker logs test0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM php:7.1-apache
 
 COPY . /var/www/html
+
+HEALTHCHECK --interval=5s CMD curl -f http://localhost/ || exit 1


### PR DESCRIPTION
This avoids the problems in the previous runs, always failing
because the curl test was done before apache was available.

Yes, a simpler `sleep 5` also fixes, but wanted to do it
using the official healthcheck support.

Side note: I'm moving this to GHA (both multi-platform container generation and test), but wanted to have it passing first.