### PR TITLE
Change health-check to detect real listening port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM php:7.1-apache
 
 COPY . /var/www/html
 
-HEALTHCHECK --interval=5s CMD curl -f http://localhost/ || exit 1
+HEALTHCHECK --interval=5s CMD curl -f http://localhost:$(cat /etc/apache2/ports.conf | grep '^Listen' | cut -d ' ' -f 2) || exit 1


### PR DESCRIPTION
This comes from https://github.com/moodlehq/moodle-docker/issues/200
where @terrycampbell detected that the recently implemented health
check for exttests was not working properly under moodle-docker.

And that's because, there, we change the exttests port to 9000
in order to workaround some limitations with podman (cannot have
2 containers publishing the same port, basically).

While more investigations happen with podman, we are changing the
check here to inspect the configuration and use the port that is
effectively being used.