### PR TITLE
Add a copy of test.html but without DTD information

### DIFF
--- a/testnodtd.html
+++ b/testnodtd.html
@@ -1,0 +1,19 @@
+<html xmlns="https://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="KEYWORDS" content="Test Page" />
+    <title>Test Page</title>
+  </head>
+  <body>
+    <p>Moodle is a software package for producing internet-based courses and web sites. It's an ongoing development project designed to support a social constructionist framework of education.</p>
+    <p>Moodle es un paquete de software para la creación de cursos y sitios Web basados en Internet. Es un proyecto en desarrollo diseñado para dar soporte a un marco de educación social constructivista.</p>
+    <p>Moodle [čti můdl] je softwarový balíček pro tvorbu výukových systémů a elektronických kurzů na internetu. Jedná se o neustále se vyvíjející projekt, navržený na základě sociálně konstruktivistického přístupu k vzdělávání.</p>
+    <p>Moodleはインターネット上で授業用のWebページを作るためのソフトです。教育学でいう社会的構築主義の考え方に基づいて作られており，日々改良が行われています。</p>
+    <hr />
+    <p>Moodle is a software package for producing internet-based courses and web sites. It's an ongoing development project designed to support a social constructionist framework of education.</p>
+    <p>Moodle es un paquete de software para la creación de cursos y sitios Web basados en Internet. Es un proyecto en desarrollo diseñado para dar soporte a un marco de educación social constructivista.</p>
+    <p>Moodle [čti můdl] je softwarový balíček pro tvorbu výukových systémů a elektronických kurzů na internetu. Jedná se o neustále se vyvíjející projekt, navržený na základě sociálně konstruktivistického přístupu k vzdělávání.</p>
+    <p>Moodleはインターネット上で授業用のWebページを作るためのソフトです。教育学でいう社会的構築主義の考え方に基づいて作られており，日々改良が行われています。</p>
+    <hr />
+    <p>Moodle is a software package for producing internet-based courses and web sites. It's an ongoing development project designed to support a social constructionist framework of education.</p>    <p>Moodle es un paquete de software para la creación de cursos y sitios Web basados en Internet. Es un proyecto en desarrollo diseñado para dar soporte a un marco de educación social constructivista.</p>    <p>Moodle [čti můdl] je softwarový balíček pro tvorbu výukových systémů a elektronických kurzů na internetu. Jedná se o neustále se vyvíjející projekt, navržený na základě sociálně konstruktivistického přístupu k vzdělávání.</p>    <p>Moodleはインターネット上で授業用のWebページを作るためのソフトです。教育学でいう社会的構築主義の考え方に基づいて作られており，日々改良が行われています。</p>  </body>
+</html>


### PR DESCRIPTION
Some tests (ims_lti) were using the test.html as fake tools
and, because that file comes with DTD specified, xmllib was
trying to download the DTD from w3c.

But w3c doesn't accept requests missing agent header, so they
were being rejected (after a 60seconds timeout).

Causing mod_lti tests to be really slow. So we are moving all
the existing tests to point to this new testnodtd.html file
to avoid the DTD loading problem. See MDL-73834 for more info.