### PR TITLE
Take current scheme (HTTP/S) in to account when redirecting.

### DIFF
--- a/test_redir.php
+++ b/test_redir.php
@@ -6,7 +6,11 @@ if (isset($_GET['done']) and $_GET['done'] == 1) {
 }
 
 // Redirect to full self URL.
-$testurl = 'http://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['SCRIPT_NAME'];
+$scheme = 'http';
+if (!empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'off') !== 0) {
+    $scheme = 'https';
+}
+$testurl = $scheme.'://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['SCRIPT_NAME'];
 
 // Determine if we require the final redirect to be an external destination.
 $extdest = isset($_GET['extdest']) ? '&extdest=' . $_GET['extdest'] : '';

--- a/test_redir.php
+++ b/test_redir.php
@@ -10,7 +10,7 @@ $scheme = 'http';
 if (!empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'off') !== 0) {
     $scheme = 'https';
 }
-$testurl = $scheme.'://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['SCRIPT_NAME'];
+$testurl = $scheme . '://' . $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['SCRIPT_NAME'];
 
 // Determine if we require the final redirect to be an external destination.
 $extdest = isset($_GET['extdest']) ? '&extdest=' . $_GET['extdest'] : '';


### PR DESCRIPTION
See MDL-79361

Failing unit tests relating to curl redirects, because download.moodle.org now redirects everything HTTP -> HTTPS with a 301 response, then the rest redirection script redirects everything back to HTTP:

```
$ curl -iL "http://download.moodle.org/unittest/test_redir.php?redir=2&verbose=1"
HTTP/1.1 301 Moved Permanently
Date: Tue, 26 Sep 2023 21:41:40 GMT
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: max-age=3600
Expires: Tue, 26 Sep 2023 22:41:40 GMT
Location: https://download.moodle.org/unittest/test_redir.php?redir=2&verbose=1
Server: cloudflare
CF-RAY: 80ceac219b0924e4-LHR

HTTP/2 302 
date: Tue, 26 Sep 2023 21:41:40 GMT
content-type: text/html; charset=UTF-8
location: http://download.moodle.org:80/unittest/test_redir.php?redir=1
cf-cache-status: DYNAMIC
server: cloudflare
cf-ray: 80ceac222e90499a-LHR

HTTP/1.1 301 Moved Permanently
Date: Tue, 26 Sep 2023 21:41:40 GMT
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: max-age=3600
Expires: Tue, 26 Sep 2023 22:41:40 GMT
Location: https://download.moodle.org/unittest/test_redir.php?redir=1
Server: cloudflare
CF-RAY: 80ceac22bcbd24e4-LHR

HTTP/2 302 
date: Tue, 26 Sep 2023 21:41:40 GMT
content-type: text/html; charset=UTF-8
location: http://download.moodle.org:80/unittest/test_redir.php?done=1
cf-cache-status: DYNAMIC
server: cloudflare
cf-ray: 80ceac22df74499a-LHR

HTTP/1.1 301 Moved Permanently
Date: Tue, 26 Sep 2023 21:41:40 GMT
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: max-age=3600
Expires: Tue, 26 Sep 2023 22:41:40 GMT
Location: https://download.moodle.org/unittest/test_redir.php?done=1
Server: cloudflare
CF-RAY: 80ceac231d5a24e4-LHR

HTTP/2 200 
date: Tue, 26 Sep 2023 21:41:41 GMT
content-type: text/html; charset=UTF-8
vary: Accept-Encoding
cf-cache-status: DYNAMIC
server: cloudflare
cf-ray: 80ceac233812499a-LHR

done
```

So the constant flip/flopping of HTTP/HTTPS breaks assumptions in our tests, e.g. those related to `CURLOPT_MAXREDIRS`